### PR TITLE
Refactor app creation androutes into own module

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -28,7 +28,7 @@ services:
         API_KEY: ${API_KEY}
     ports:
       - "8000:8000"
-    command: ["uvicorn", "dds_glossary.main:app", "--host", "0.0.0.0"]
+    command: ["python", "-m", "dds_glossary.main"]
     depends_on:
       glossary_postgres:
         condition: service_healthy

--- a/dds_glossary/main.py
+++ b/dds_glossary/main.py
@@ -1,194 +1,48 @@
 """Main entry for the dds_glossary server."""
+
+import argparse
+from http import HTTPStatus
 from os import getenv
 
-from http import HTTPStatus
-
-from fastapi import Depends, FastAPI, Request
-from fastapi.responses import JSONResponse
-from fastapi.templating import Jinja2Templates
 import sentry_sdk
-from starlette.templating import _TemplateResponse
+import uvicorn
+from fastapi import FastAPI
+from fastapi.templating import Jinja2Templates
 
 from . import __version__
-from .auth import get_api_key
 from .controllers import GlossaryController
+from .routes import router
 
 
-SENTRY_DSN=getenv("SENTRY_DSN")
-
-sentry_sdk.init(
-    dsn=SENTRY_DSN,
-    # Set traces_sample_rate to 1.0 to capture 100%
-    # of transactions for performance monitoring.
-    traces_sample_rate=1.0,
-    # Set profiles_sample_rate to 1.0 to profile 100%
-    # of sampled transactions.
-    # We recommend adjusting this value in production.
-    profiles_sample_rate=1.0,
-)
-
-app = FastAPI()
-controller = GlossaryController()
-templates = Jinja2Templates(directory="templates")
-
-
-@app.get("/")
-def home(
-    request: Request,
-    search_term: str = "",
-    concept_scheme_iri: str = "",
-    lang: str = "en",
-) -> _TemplateResponse:
-    """Get the home page.
-    If a `search_term` term is provided, it will filter the concepts by the search term.
-    If a `concept_scheme_iri` is provided, it will filter the concepts by the concept
-    scheme.
-
-    Args:
-        request (Request): The request.
-        search_term (str): The search term to filter the concepts. Defaults to "".
-        concept_scheme_iri (str): The concept scheme IRI to filter the concepts.
-            Defaults to "".
-        lang (str): The language to use for searching concepts. Defaults to "en".
-
+def create_app() -> FastAPI:
+    """Create the FastAPI application object
     Returns:
-        _TemplateResponse: The home page with search results if any.
+        FastAPI: the application object
     """
-    if concept_scheme_iri:
-        concepts = controller.get_concepts(concept_scheme_iri, lang=lang)
-    else:
-        concepts = controller.search_database(search_term, lang=lang)
 
-    return templates.TemplateResponse(
-        "home.html",
-        {
-            "request": request,
-            "schemes": controller.get_concept_schemes(lang=lang),
-            "concepts": concepts,
-        },
+    SENTRY_DSN = getenv("SENTRY_DSN")
+
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        traces_sample_rate=1.0,
+        # Set profiles_sample_rate to 1.0 to profile 100%
+        # of sampled transactions.
+        # We recommend adjusting this value in production.
+        profiles_sample_rate=1.0,
     )
+    app = FastAPI()
+    app.state.controller = GlossaryController()
+    app.state.templates = Jinja2Templates(directory="templates")
+    app.include_router(router)
+    return app
 
-@app.get("/search")
-def search(
-    search_term: str ,
-    lang: str = "en",
-) -> JSONResponse:
-    """Search concepts according to given expression.
-    Note: This will be removed once #35 (Add elasticsearch) is closed.
 
-    Args:
-        search_term (str): The search term to filter the concepts.
-        lang (str): The language to use for searching concepts. Defaults to "en".
-
-    Returns:
-        JSONResponse: The search results, if any.
-    """
-    return JSONResponse(
-        content={
-            "schemes": controller.get_concept_schemes(lang=lang),
-            "concepts": controller.search_database(search_term, lang=lang),
-        },
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="DDS Glossary")
+    parser.add_argument(
+        "-r", dest="f_reload", action="store_true", help="enable auto-reloading"
     )
-
-
-@app.get("/version")
-def get_version() -> JSONResponse:
-    """Get the version of the server.
-
-    Returns:
-        JSONResponse: The version of the server.
-    """
-    return JSONResponse(
-        content={
-            "version": __version__,
-        },
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
-    )
-
-
-@app.post("/init_datasets")
-def init_datasets(
-    _api_key: dict = Depends(get_api_key),
-    reload: bool = False,
-) -> JSONResponse:
-    """Initialize the datasets.
-
-    Args:
-        _api_key (dict): The API key.
-        reload (bool): Flag to reload the datasets. Defaults to False.
-
-    Returns:
-        JSONResponse: The status of the init request.
-    """
-    saved_datasets, failed_datasets = controller.init_datasets(reload=reload)
-    return JSONResponse(
-        content={
-            "saved_datasets": saved_datasets,
-            "failed_datasets": failed_datasets,
-        },
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
-    )
-
-
-@app.get("/schemes")
-def get_concept_schemes(lang: str = "en") -> JSONResponse:
-    """
-    Returns all the saved concept schemes.
-
-    Args:
-        lang (str): The language. Defaults to "en".
-
-    Returns:
-        JSONResponse: The concept schemes.
-    """
-    return JSONResponse(
-        content={
-            "concept_schemes": controller.get_concept_schemes(lang=lang),
-        },
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
-    )
-
-
-@app.get("/concepts")
-def get_concepts(concept_scheme_iri: str, lang: str = "en") -> JSONResponse:
-    """
-    Returns all the saved concepts for a concept scheme.
-
-    Args:
-        concept_scheme_iri (str): The concept scheme IRI.
-        lang (str): The language. Defaults to "en".
-
-    Returns:
-        JSONResponse: The concepts.
-    """
-    return JSONResponse(
-        content={
-            "concepts": controller.get_concepts(concept_scheme_iri, lang=lang),
-        },
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
-    )
-
-
-@app.get("/concept")
-def get_concept(concept_iri: str, lang: str = "en") -> JSONResponse:
-    """
-    Returns a concept.
-
-    Args:
-        concept_iri (str): The concept IRI.
-        lang (str): The language. Defaults to "en".
-
-    Returns:
-        JSONResponse: The concept.
-    """
-    return JSONResponse(
-        content=controller.get_concept(concept_iri, lang=lang),
-        media_type="application/json",
-        status_code=HTTPStatus.OK,
-    )
+    args = parser.parse_args()
+    uvicorn.run("dds_glossary.main:create_app", reload=args.f_reload, host="0.0.0.0")

--- a/dds_glossary/routes.py
+++ b/dds_glossary/routes.py
@@ -1,0 +1,189 @@
+import logging
+from http import HTTPStatus
+
+from fastapi import APIRouter, Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.templating import _TemplateResponse
+
+from . import __version__
+from .auth import get_api_key
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/")
+def home(
+    request: Request,
+    search_term: str = "",
+    concept_scheme_iri: str = "",
+    lang: str = "en",
+) -> _TemplateResponse:
+    """Get the home page.
+    If a `search_term` term is provided, it will filter the concepts by the search term.
+    If a `concept_scheme_iri` is provided, it will filter the concepts by the concept
+    scheme.
+
+    Args:
+        request (Request): The request.
+        search_term (str): The search term to filter the concepts. Defaults to "".
+        concept_scheme_iri (str): The concept scheme IRI to filter the concepts.
+            Defaults to "".
+        lang (str): The language to use for searching concepts. Defaults to "en".
+
+    Returns:
+        _TemplateResponse: The home page with search results if any.
+    """
+    if concept_scheme_iri:
+        concepts = request.app.state.controller.get_concepts(
+            concept_scheme_iri, lang=lang
+        )
+    else:
+        concepts = request.app.state.controller.search_database(search_term, lang=lang)
+
+    return request.app.state.templates.TemplateResponse(
+        "home.html",
+        {
+            "request": request,
+            "schemes": request.app.state.controller.get_concept_schemes(lang=lang),
+            "concepts": concepts,
+        },
+    )
+
+
+@router.get("/search")
+def search(
+    request: Request,
+    search_term: str,
+    lang: str = "en",
+) -> JSONResponse:
+    """Search concepts according to given expression.
+    Note: This will be removed once #35 (Add elasticsearch) is closed.
+
+    Args:
+        search_term (str): The search term to filter the concepts.
+        lang (str): The language to use for searching concepts. Defaults to "en".
+
+    Returns:
+        JSONResponse: The search results, if any.
+    """
+    return JSONResponse(
+        content={
+            "schemes": request.app.state.controller.get_concept_schemes(lang=lang),
+            "concepts": request.app.state.controller.search_database(
+                search_term, lang=lang
+            ),
+        },
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.get("/version")
+def get_version() -> JSONResponse:
+    """Get the version of the server.
+
+    Returns:
+        JSONResponse: The version of the server.
+    """
+    return JSONResponse(
+        content={
+            "version": __version__,
+        },
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.post("/init_datasets")
+def init_datasets(
+    request: Request,
+    _api_key: dict = Depends(get_api_key),
+    reload: bool = False,
+) -> JSONResponse:
+    """Initialize the datasets.
+
+    Args:
+        _api_key (dict): The API key.
+        reload (bool): Flag to reload the datasets. Defaults to False.
+
+    Returns:
+        JSONResponse: The status of the init request.
+    """
+    saved_datasets, failed_datasets = request.app.state.controller.init_datasets(
+        reload=reload
+    )
+    return JSONResponse(
+        content={
+            "saved_datasets": saved_datasets,
+            "failed_datasets": failed_datasets,
+        },
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.get("/schemes")
+def get_concept_schemes(request: Request, lang: str = "en") -> JSONResponse:
+    """
+    Returns all the saved concept schemes.
+
+    Args:
+        lang (str): The language. Defaults to "en".
+
+    Returns:
+        JSONResponse: The concept schemes.
+    """
+    return JSONResponse(
+        content={
+            "concept_schemes": request.app.state.controller.get_concept_schemes(
+                lang=lang
+            ),
+        },
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.get("/concepts")
+def get_concepts(
+    request: Request, concept_scheme_iri: str, lang: str = "en"
+) -> JSONResponse:
+    """
+    Returns all the saved concepts for a concept scheme.
+
+    Args:
+        concept_scheme_iri (str): The concept scheme IRI.
+        lang (str): The language. Defaults to "en".
+
+    Returns:
+        JSONResponse: The concepts.
+    """
+    return JSONResponse(
+        content={
+            "concepts": request.app.state.controller.get_concepts(
+                concept_scheme_iri, lang=lang
+            ),
+        },
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )
+
+
+@router.get("/concept")
+def get_concept(request: Request, concept_iri: str, lang: str = "en") -> JSONResponse:
+    """
+    Returns a concept.
+
+    Args:
+        concept_iri (str): The concept IRI.
+        lang (str): The language. Defaults to "en".
+
+    Returns:
+        JSONResponse: The concept.
+    """
+    return JSONResponse(
+        content=request.app.state.controller.get_concept(concept_iri, lang=lang),
+        media_type="application/json",
+        status_code=HTTPStatus.OK,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,7 @@ from sqlalchemy_utils import database_exists, drop_database
 
 from dds_glossary.controllers import GlossaryController
 from dds_glossary.database import init_engine
-from dds_glossary.main import app
-from dds_glossary.main import controller as app_controller
+from dds_glossary.main import create_app
 from dds_glossary.model import Concept, ConceptScheme, InScheme, SemanticRelation
 
 
@@ -89,8 +88,9 @@ def _controller(tmp_path: Path) -> Generator[GlossaryController, None, None]:
 
 @fixture(name="client")
 def _client(tmp_path: Path) -> Generator[TestClient, None, None]:
-    app_controller.data_dir = tmp_path
-    app_controller.engine = init_engine(drop_database_flag=True)
+    app = create_app()
+    app.state.controller.data_dir = tmp_path
+    app.state.controller.engine = init_engine(drop_database_flag=True)
     with TestClient(app) as client:
         yield client
-    _clean_database(app_controller.engine)
+    _clean_database(app.state.controller.engine)

--- a/tests/integration/test_fresh_start.py
+++ b/tests/integration/test_fresh_start.py
@@ -10,12 +10,11 @@ from owlready2 import onto_path
 
 from dds_glossary import __version__
 from dds_glossary.controllers import GlossaryController
-from dds_glossary.main import controller
 
 
 def test_fresh_start(client: TestClient, dir_data: Path) -> None:
     """Test the /fresh_start endpoint."""
-    controller.data_dir = dir_data
+    client.app.state.controller.data_dir = dir_data
     onto_path.append(str(dir_data))
     saved_dataset_file = "sample.rdf"
     saved_database_url = "https://example.com/sample.rdf"


### PR DESCRIPTION
* Uvicorn now runs directly on `__main__`
* Add argparser for useful cmd args such as live reload
* Move app creation to `create_app` function for reusability
* Move routes into own module. This creates a temporary (to be refactored) dependency injection on the `app.state` since the controller and template object is being attached directly. Not great but will change later.